### PR TITLE
Updating .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ before_install:
     - export PATH=`pwd`/miniconda/bin:$PATH
     - conda update --yes conda
     - conda config --append channels conda-forge
+    - conda config --set channel_priority strict
     - conda create -y -q -n test-env python=$TRAVIS_PYTHON_VERSION 
     - source activate test-env
     - conda install -y numpy scipy pandas six pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
     - conda update --yes conda
     - conda config --append channels conda-forge
     - conda config --set channel_priority strict
-    - conda create -y -q -n test-env python=$TRAVIS_PYTHON_VERSION 
+    - conda create -y -q -n test-env python=$TRAVIS_PYTHON_VERSION
     - source activate test-env
     - conda install -y numpy scipy pandas six pip
     - conda install -y nose seaborn dill statsmodels geopandas

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
     - 3.6
 
 before_install:
-    - wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+    - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
     - chmod +x miniconda.sh
     - ./miniconda.sh -b -p ./miniconda
     - export PATH=`pwd`/miniconda/bin:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,12 @@ branches:
     - master
     - dev
 
-python:
-    - 3.5
-    - 3.6
+matrix:
+  include:
+    - python: 3.6
+    - python: 3.7
+      dist: xenial
+      sudo: true
 
 before_install:
     - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ before_install:
     - ./miniconda.sh -b -p ./miniconda
     - export PATH=`pwd`/miniconda/bin:$PATH
     - conda update --yes conda
+    - conda config --append channels conda-forge
     - conda create -y -q -n test-env python=$TRAVIS_PYTHON_VERSION 
     - source activate test-env
     - conda install -y numpy scipy pandas six pip


### PR DESCRIPTION
This PR begins the updating process of `.travis.yml` and will end with the introduction of `python 3.7` support (and dropping support for `python 3.5`).