### PR TITLE
addressing pysal #1139 & new libpysal.examples schema

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,7 @@ before_install:
 install:
     - python setup.py install
 script:
-    - python -c 'import libpysal; \
-        libpysal.examples.load_example("South"); \
-        libpysal.examples.load_example("Baltimore")'
+    - python -c 'import libpysal; libpysal.examples.load_example("South"); libpysal.examples.load_example("Baltimore")'
     - python -c 'from spvcm import diagnostics; print(diagnostics._HAS_CODA, diagnostics._HAS_RPY2)'
     - travis_wait 45 nosetests spvcm
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,9 @@ before_install:
 install:
     - python setup.py install
 script:
+    - python -c 'import libpysal; \
+        libpysal.examples.load_example("South"); \
+        libpysal.examples.load_example("Baltimore")'
     - python -c 'from spvcm import diagnostics; print(diagnostics._HAS_CODA, diagnostics._HAS_RPY2)'
     - travis_wait 45 nosetests spvcm
 

--- a/spvcm/abstracts.py
+++ b/spvcm/abstracts.py
@@ -52,7 +52,6 @@ class Sampler_Mixin(object):
             tqdm = thru_op
             msg = '`tqdm` is not available. '
             msg += 'Using `spvcm.utils.thru_op` in place of `tqdm`.'
-            
             warn(msg, stacklevel=2)
             
         if n_jobs > 1:

--- a/spvcm/abstracts.py
+++ b/spvcm/abstracts.py
@@ -50,6 +50,10 @@ class Sampler_Mixin(object):
         except ImportError:
             from .utils import thru_op
             tqdm = thru_op
+            msg = '`tqdm` is not available. '
+            msg += 'Using `spvcm.utils.thru_op` in place of `tqdm`.'
+            
+            warn(msg, stacklevel=2)
             
         if n_jobs > 1:
            self._parallel_sample(n_samples, n_jobs)

--- a/spvcm/abstracts.py
+++ b/spvcm/abstracts.py
@@ -6,18 +6,14 @@ import multiprocessing as mp
 import pandas as pd
 import os
 
-
 from .sqlite import head_to_sql, start_sql
 from .plotting import plot_trace
 from collections import OrderedDict
-try:
-    from tqdm import tqdm
-    import six
-    if not six.PY3:
-        range = xrange
-except ImportError:
-    from .utils import thru_op
-    tqdm = thru_op
+
+import six
+if not six.PY3:
+    range = xrange
+
 
 __all__ = ['Sampler_Mixin', 'Hashmap', 'Trace']
 
@@ -49,6 +45,12 @@ class Sampler_Mixin(object):
         -------
         Implicitly updates all values in place, returns None
         """
+        try:
+            from tqdm import tqdm
+        except ImportError:
+            from .utils import thru_op
+            tqdm = thru_op
+            
         if n_jobs > 1:
            self._parallel_sample(n_samples, n_jobs)
            return

--- a/spvcm/abstracts.py
+++ b/spvcm/abstracts.py
@@ -52,7 +52,7 @@ class Sampler_Mixin(object):
             tqdm = thru_op
             msg = '`tqdm` is not available. '
             msg += 'Using `spvcm.utils.thru_op` in place of `tqdm`.'
-            warn(msg, stacklevel=2)
+            warnings.warn(msg, stacklevel=2)
             
         if n_jobs > 1:
            self._parallel_sample(n_samples, n_jobs)

--- a/spvcm/sqlite.py
+++ b/spvcm/sqlite.py
@@ -3,13 +3,12 @@ import numpy as np
 import os
 import sys
 from warnings import warn
+import pickle as pkl
 try:
     import dill
-    import pickle as pkl
 except ImportError as E:
     msg = 'The `dill` module is required to use the sqlite backend fully.'
     warn(msg, stacklevel=2)
-    import pickle as pkl
 LEGACY_PYTHON = sys.version_info[0] < 3
 
 CREATE_TEMPLATE = "CREATE TABLE {} (iteration INTEGER PRIMARY KEY, {})"

--- a/spvcm/sqlite.py
+++ b/spvcm/sqlite.py
@@ -2,7 +2,7 @@ import sqlite3 as sql
 import numpy as np
 import os
 import sys
-from warnings import warn
+import warnings
 import pickle as pkl
 
 LEGACY_PYTHON = sys.version_info[0] < 3
@@ -141,7 +141,7 @@ def maybe_deserialize(maybe_bytestring):
         import dill
     except ImportError as E:
         msg = 'The `dill` module is required to use the sqlite backend fully.'
-        warn(msg, stacklevel=2)
+        warnings.warn(msg, stacklevel=2)
     
     if isinstance(maybe_bytestring, (list, tuple)):
         return type(maybe_bytestring)([maybe_deserialize(byte_element) 

--- a/spvcm/sqlite.py
+++ b/spvcm/sqlite.py
@@ -4,11 +4,7 @@ import os
 import sys
 from warnings import warn
 import pickle as pkl
-try:
-    import dill
-except ImportError as E:
-    msg = 'The `dill` module is required to use the sqlite backend fully.'
-    warn(msg, stacklevel=2)
+
 LEGACY_PYTHON = sys.version_info[0] < 3
 
 CREATE_TEMPLATE = "CREATE TABLE {} (iteration INTEGER PRIMARY KEY, {})"
@@ -141,6 +137,12 @@ def maybe_deserialize(maybe_bytestring):
     This attempts to deserialize an object, but may return the original object 
     if no deserialization is successful. 
     """
+    try:
+        import dill
+    except ImportError as E:
+        msg = 'The `dill` module is required to use the sqlite backend fully.'
+        warn(msg, stacklevel=2)
+    
     if isinstance(maybe_bytestring, (list, tuple)):
         return type(maybe_bytestring)([maybe_deserialize(byte_element) 
                                         for byte_element in maybe_bytestring])

--- a/spvcm/utils.py
+++ b/spvcm/utils.py
@@ -63,7 +63,8 @@ def south(df=False):
     and the dataframe contains the raw dataset
     """
     import geopandas
-    data = geopandas.read_file(libpysal.examples.get_path('south.shp'))
+    south = libpysal.examples.load_example('South')
+    data = geopandas.read_file(south.get_path('south.shp'))
     data = data[data.STATE_NAME != 'District of Columbia']
     X = data[['GI89', 'BLK90', 'HR90']].values
     N = X.shape[0]
@@ -72,11 +73,12 @@ def south(df=False):
     J = Z.shape[0]
 
     Y = data.DNL90.values.reshape(-1,1)
-
-    W2 = libpysal.weights.Queen.from_shapefile(libpysal.examples.get_path('us48.shp'),
+    
+    us48 = libpysal.examples.load_example('us_income')
+    W2 = libpysal.weights.Queen.from_shapefile(us48.get_path('us48.shp'),
                                                idVariable='STATE_NAME')
     W2 = libpysal.weights.set_operations.w_subset(W2, ids=data.STATE_NAME.unique().tolist()) #only keep what's in the data
-    W1 = libpysal.weights.Queen.from_shapefile(libpysal.examples.get_path('south.shp'),
+    W1 = libpysal.weights.Queen.from_shapefile(south.get_path('south.shp'),
                                             idVariable='FIPS')
     W1 = libpysal.weights.set_operations.w_subset(W1, ids=data.FIPS.tolist()) #again, only keep what's in the data
 
@@ -106,7 +108,8 @@ def baltim(df=False):
     dataframe contains the raw data of the baltimore example
     """
     import geopandas
-    baltim = geopandas.read_file(libpysal.examples.get_path('baltim.shp'))
+    baltim = libpysal.examples.load_example('Baltimore')
+    baltim = geopandas.read_file(baltim.get_path('baltim.shp'))
     coords = baltim[['X', 'Y']].values
     Y = np.log(baltim.PRICE.values).reshape(-1,1)
     Yz = Y - Y.mean()


### PR DESCRIPTION
This PR address both pysal/pysal#1139 and the new `libpysal.examples` schema introduced in [`libpysal` v4.2](https://github.com/pysal/libpysal/releases/tag/v4.2.0).

As far as the `try`/`except` block in [`spvcm.diagnostics`](https://github.com/pysal/spvcm/blob/63a23adf9fb8bf28e64d4b692018aae15222d816/spvcm/diagnostics.py#L11-L25) (also see below), placing this chunk within the function would have to happen in both [`summarize`](https://github.com/pysal/spvcm/blob/63a23adf9fb8bf28e64d4b692018aae15222d816/spvcm/diagnostics.py#L64) and [`_effective_size`](https://github.com/pysal/spvcm/blob/63a23adf9fb8bf28e64d4b692018aae15222d816/spvcm/diagnostics.py#L451-L457) (without some [minor] refactoring).



```python
try:
    from rpy2.rinterface import RRuntimeError
    from rpy2.robjects.packages import importr
    from rpy2.robjects.numpy2ri import numpy2ri
    import rpy2.robjects as ro
    ro.conversion.py2ri = numpy2ri
    _coda = importr('coda')
    _HAS_CODA = True
    _HAS_RPY2 = True
except (ImportError, LookupError):
    _HAS_CODA = False
    _HAS_RPY2 = False
except RRuntimeError:
    _HAS_CODA = False
    _HAS_RPY2 = True
```